### PR TITLE
Tag additional hediffs as non-bad

### DIFF
--- a/1.4/Defs/HediffDefs/Hediffs_Global_Misc.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Global_Misc.xml
@@ -45,6 +45,7 @@
 				<restFallFactor>0.5</restFallFactor>
 			</li>
 		</stages>
+		<isBad>false</isBad>
 	</HediffDef>
 	<HediffDef>
 		<defName>GR_VeryLowRest</defName>
@@ -58,6 +59,7 @@
 				<restFallFactor>0.01</restFallFactor>
 			</li>
 		</stages>
+		<isBad>false</isBad>
 	</HediffDef>
 	<HediffDef>
 		<defName>GR_PackTactics</defName>
@@ -841,6 +843,7 @@
 				</statOffsets>
 			</li>
 		</stages>
+		<isBad>false</isBad>
 	</HediffDef>
 	<HediffDef>
 		<defName>GR_MeleeDodge</defName>
@@ -856,6 +859,7 @@
 				</statOffsets>
 			</li>
 		</stages>
+		<isBad>false</isBad>
 	</HediffDef>
 	<HediffDef>
 		<defName>GR_SadisticAdrenaline</defName>

--- a/1.4/Defs/HediffDefs/Hediffs_Local_Implants_Animals.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Implants_Animals.xml
@@ -26,6 +26,7 @@
 				<makeNonFleeingToo>true</makeNonFleeingToo>
 			</li>
 		</comps>
+		<isBad>false</isBad>
 	</HediffDef>
 	
 	<!--=============== Animal Hybrid Implants ====================-->


### PR DESCRIPTION
## Changes
* Tagged the following hediffs with `<isBad>false</isBad>`:
  * `GR_AnimalControlHediff`
  * `GR_LowRest`
  * `GR_MeleeDodge`
  * `GR_NoPain`
  * `GR_VeryLowRest`

## Rationale
* The aforementioned hediffs are (presumably) meant to apply permanent buffs to various hybrids
  * Other similar hediffs in VGE have already been tagged correctly
* Mod compatibility with MedPod, by marking them as untreatable