### PR TITLE
Fix pawns picking up 20 poison ampoules to ingest 1

### DIFF
--- a/1.5/Defs/Drugs/PoisonAmpoule.xml
+++ b/1.5/Defs/Drugs/PoisonAmpoule.xml
@@ -36,6 +36,7 @@
       <ingestReportString>Taking {0}.</ingestReportString>
       <preferability>NeverForNutrition</preferability>
       <maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
+      <defaultNumToIngestAtOnce>1</defaultNumToIngestAtOnce>
      
     </ingestible>
 	 <socialPropernessMatters>true</socialPropernessMatters>


### PR DESCRIPTION
Same issue as Vanilla-Expanded/VanillaCookingExpanded#2, pawns end up picking stacks of 20 ampoules when they only ingest 1.