### PR TITLE
Dev mode gizmos require dev mode, archocentipede former gizmo fixed

### DIFF
--- a/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_ArchoWomb.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_ArchoWomb.cs
@@ -155,7 +155,7 @@ namespace GeneticRim
 
                 }
                 yield return command_Action;
-                if (Prefs.DevMode && this.wombProgress != -1)
+                if (DebugSettings.ShowDevGizmos && this.wombProgress != -1)
                 {
                     Command_Action command_Action2 = new Command_Action();
                     command_Action2.defaultLabel = "DEBUG: Finish womb work";

--- a/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_ArchocentipedeFormer.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_ArchocentipedeFormer.cs
@@ -149,7 +149,7 @@ namespace GeneticRim
 
                 }
                 yield return command_Action;
-                if (Prefs.DevMode && this.growthCellProgress != -1)
+                if (DebugSettings.ShowDevGizmos && this.growthCellProgress != -1)
                 {
                     Command_Action command_Action2 = new Command_Action();
                     command_Action2.defaultLabel = "DEBUG: Finish former work";
@@ -159,7 +159,7 @@ namespace GeneticRim
                         this.growthCellProgress = 1;
 
                     };
-                    yield return command_Action;
+                    yield return command_Action2;
 
                 }
             }

--- a/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_DNAStorageBank.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_DNAStorageBank.cs
@@ -63,7 +63,7 @@ namespace GeneticRim
 
 
                     yield return GenomeListSetupUtility.SetAnimalListCommand(this, this.Map, this.selectedGenome);
-                    if (Prefs.DevMode)
+                    if (DebugSettings.ShowDevGizmos)
                     {
                         Command_Action command_Action = new Command_Action();
                         command_Action.defaultLabel = "DEBUG: Finish DNA progress";

--- a/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_Mechahybridizer.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_Mechahybridizer.cs
@@ -43,7 +43,7 @@ namespace GeneticRim
             }
 
             yield return GenomeListSetupUtility.SetParagonListCommand(this, this.Map);
-            if (Prefs.DevMode && this.progress != -1)
+            if (DebugSettings.ShowDevGizmos && this.progress != -1)
             {
                 Command_Action command_Action2 = new Command_Action();
                 command_Action2.defaultLabel = "DEBUG: Finish work";

--- a/1.5/Source/GeneticRim/GeneticRim/Comps/CompApplyAgeDiseases.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Comps/CompApplyAgeDiseases.cs
@@ -94,7 +94,7 @@ namespace GeneticRim
         public IEnumerable<Gizmo> GetGizmos()
         {
 
-            if (Prefs.DevMode)
+            if (DebugSettings.ShowDevGizmos)
             {
                 Command_Action command_Action = new Command_Action();
                 command_Action.defaultLabel = "DEBUG: Give age related diseases";

--- a/1.5/Source/GeneticRim/GeneticRim/Comps/CompElectroWomb.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Comps/CompElectroWomb.cs
@@ -274,7 +274,7 @@ namespace GeneticRim
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
             
-            if (Prefs.DevMode)
+            if (DebugSettings.ShowDevGizmos)
             {
                 Command_Action command_Action = new Command_Action();
                 command_Action.defaultLabel = "DEBUG: Finish womb work";

--- a/1.5/Source/GeneticRim/GeneticRim/Comps/CompGenomorpher.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Comps/CompGenomorpher.cs
@@ -141,7 +141,7 @@ namespace GeneticRim
 
             }
             
-            if (Prefs.DevMode)
+            if (DebugSettings.ShowDevGizmos)
             {
                 Command_Action command_Action = new Command_Action();
                 command_Action.defaultLabel = "DEBUG: Finish growth cell";


### PR DESCRIPTION
All dev mode gizmos now check for `DebugSettings.ShowDevGizmos` rather than `Prefs.DevMode`. On top of that the archocentipede former dev mode gizmo will now be actually displayed (previously the gizmo to start the growth cell progress was returned a second time, but I believe it got merged with the original gizmo).