### PR TITLE
Add a new line to DNA storage bank inspect string

### DIFF
--- a/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_DNAStorageBank.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Buildings/Building_DNAStorageBank.cs
@@ -110,6 +110,7 @@ namespace GeneticRim
 
             if (selectedGenome != null)
             {
+                sb.AppendLine();
                 sb.AppendLine("GR_SelectedGenome".Translate(selectedGenome.LabelCap));
                 sb.AppendLine("GR_DNABankProgress".Translate(this.progress.ToStringPercent()));
             }


### PR DESCRIPTION
DNA storage bank currently has an issue where its comp text overlaps with the building text in its inspect string. I've fixed this by adding a new line to the text.