### PR TITLE
Apply quality hediff on natural birth of hybrid.

### DIFF
--- a/1.5/Source/GeneticRim/GeneticRim/Comps/CompElectroWomb.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Comps/CompElectroWomb.cs
@@ -156,40 +156,7 @@ namespace GeneticRim
                         if (compHybrid != null) {
                             compHybrid.quality = this.genoframe?.GetModExtension<DefExtension_Quality>()?.quality ?? QualityCategory.Awful;
 
-
-                            if (pawn.def.tradeTags?.Contains("AnimalGeneticMechanoid") == false)
-                            {
-                                pawn.health.AddHediff(InternalDefOf.GR_HungerByQuality);
-                                float severity = 0.2f;
-                                switch (compHybrid.quality)
-                                {
-                                    case QualityCategory.Awful:
-                                        severity = 0f;
-                                        break;
-                                    case QualityCategory.Poor:
-                                        severity = 0.1f;
-                                        break;
-                                    case QualityCategory.Normal:
-                                        severity = 0.2f;
-                                        break;
-                                    case QualityCategory.Good:
-                                        severity = 0.3f;
-                                        break;
-                                    case QualityCategory.Excellent:
-                                        severity = 0.4f;
-                                        break;
-                                    case QualityCategory.Masterwork:
-                                        severity = 0.5f;
-                                        break;
-                                    case QualityCategory.Legendary:
-                                        severity = 0.6f;
-                                        break;
-
-                                }
-                                pawn.health.hediffSet.GetFirstHediffOfDef(InternalDefOf.GR_HungerByQuality).Severity = severity;
-
-                            }
-
+                            Core.ApplyQualityHediff(pawn, compHybrid.quality);
 
                         }
                         if (failureResult == InternalDefOf.GR_FleshGrowth && failure) { this.parent.Destroy(); }

--- a/1.5/Source/GeneticRim/GeneticRim/Core.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Core.cs
@@ -15,6 +15,17 @@
         public static HashSet<PawnKindDef>                                    hybridPawnKinds;
         public static List<PawnKindDef>                                       failures;
 
+        private static readonly Dictionary<QualityCategory, float> QualitySeverityMap = new Dictionary<QualityCategory, float>
+        {
+            { QualityCategory.Awful, 0f },
+            { QualityCategory.Poor, 0.1f },
+            { QualityCategory.Normal, 0.2f },
+            { QualityCategory.Good, 0.3f },
+            { QualityCategory.Excellent, 0.4f },
+            { QualityCategory.Masterwork, 0.5f },
+            { QualityCategory.Legendary, 0.6f }
+        };
+
         static Core()
         {
             genomes = DefDatabase<ThingDef>.AllDefs.Where(x => x.thingCategories?.Contains(InternalDefOf.GR_GeneticMaterial) ?? false).ToList();
@@ -138,30 +149,10 @@
             if (pawn.def.tradeTags?.Contains("AnimalGeneticMechanoid") == false)
             {
                 pawn.health.AddHediff(InternalDefOf.GR_HungerByQuality);
-                float severity = 0.2f;
-                switch (quality)
+                bool mappingFound = QualitySeverityMap.TryGetValue(quality, out float severity);
+                if (!mappingFound)
                 {
-                    case QualityCategory.Awful:
-                        severity = 0f;
-                        break;
-                    case QualityCategory.Poor:
-                        severity = 0.1f;
-                        break;
-                    case QualityCategory.Normal:
-                        severity = 0.2f;
-                        break;
-                    case QualityCategory.Good:
-                        severity = 0.3f;
-                        break;
-                    case QualityCategory.Excellent:
-                        severity = 0.4f;
-                        break;
-                    case QualityCategory.Masterwork:
-                        severity = 0.5f;
-                        break;
-                    case QualityCategory.Legendary:
-                        severity = 0.6f;
-                        break;
+                    severity = 0.2f;
                 }
                 pawn.health.hediffSet.GetFirstHediffOfDef(InternalDefOf.GR_HungerByQuality).Severity = severity;
             }

--- a/1.5/Source/GeneticRim/GeneticRim/Core.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Core.cs
@@ -133,6 +133,40 @@
             return null;
         }
 
+        public static void ApplyQualityHediff(Pawn pawn, QualityCategory quality)
+        {
+            if (pawn.def.tradeTags?.Contains("AnimalGeneticMechanoid") == false)
+            {
+                pawn.health.AddHediff(InternalDefOf.GR_HungerByQuality);
+                float severity = 0.2f;
+                switch (quality)
+                {
+                    case QualityCategory.Awful:
+                        severity = 0f;
+                        break;
+                    case QualityCategory.Poor:
+                        severity = 0.1f;
+                        break;
+                    case QualityCategory.Normal:
+                        severity = 0.2f;
+                        break;
+                    case QualityCategory.Good:
+                        severity = 0.3f;
+                        break;
+                    case QualityCategory.Excellent:
+                        severity = 0.4f;
+                        break;
+                    case QualityCategory.Masterwork:
+                        severity = 0.5f;
+                        break;
+                    case QualityCategory.Legendary:
+                        severity = 0.6f;
+                        break;
+                }
+                pawn.health.hediffSet.GetFirstHediffOfDef(InternalDefOf.GR_HungerByQuality).Severity = severity;
+            }
+        }
+
         public static QualityCategory? GetQualityFromGenoframe(ThingDef genoframe)
         {
             var extension = genoframe.GetModExtension<DefExtension_Quality>();

--- a/1.5/Source/GeneticRim/GeneticRim/Harmony/CompHatcher_Hatch.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Harmony/CompHatcher_Hatch.cs
@@ -59,7 +59,7 @@ namespace GeneticRim
                 if (compHybrid != null)
                 {
                     compHybrid.quality = (QualityCategory)Math.Min((sbyte)qualityMother, (sbyte)qualityFather);
-
+                    Core.ApplyQualityHediff(pawn, compHybrid.quality);
                 }
                 
             }

--- a/1.5/Source/GeneticRim/GeneticRim/Harmony/Hediff_Pregnant_DoBirthSpawn.cs
+++ b/1.5/Source/GeneticRim/GeneticRim/Harmony/Hediff_Pregnant_DoBirthSpawn.cs
@@ -64,8 +64,7 @@ namespace GeneticRim
                     {
                         compHybrid.quality = qualityMother;
                     }
-                    
-
+                    Core.ApplyQualityHediff(pawn, compHybrid.quality);
                 }
                 
             }


### PR DESCRIPTION
Apply quality hediff on natural birth of hybrid + Pawn hatching from egg.

Has been tested in dev mode and currently running save.

Other changes:
- Extract out logic in electrowomb that applies quality hediff to static helper method in core.
  - Chose this location due to `GetQualityFromGenoframe` static helper existing here already.
- Use helper function in electrowomb as not to introduce code duplication.